### PR TITLE
Tell raster API to use cloudferro s3

### DIFF
--- a/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
+++ b/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
@@ -44,6 +44,8 @@ pgstacBootstrap:
 raster:
   enabled: true
   settings:
+    envVars:
+      AWS_S3_ENDPOINT: "https://s3.waw3-2.cloudferro.com"
     resources:
       requests:
         memory: "3072Mi"

--- a/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
+++ b/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
@@ -46,6 +46,10 @@ raster:
   settings:
     envVars:
       AWS_S3_ENDPOINT: "https://s3.waw3-2.cloudferro.com"
+      AWS_S3_ACCESS_SECRET: "MBiw2FOddg3Fs2Rm9NoDy10qufvJ4hzjmlQ1qwzV"
+      AWS_S3_ACCESS_KEY: "4SMIGZNCR8LM1LSUY1HU"
+      AWS_S3_REGION: "WAW3-2"
+
     resources:
       requests:
         memory: "3072Mi"

--- a/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
+++ b/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
@@ -46,10 +46,12 @@ raster:
   settings:
     envVars:
       AWS_S3_ENDPOINT: "https://s3.waw3-2.cloudferro.com"
-      AWS_S3_ACCESS_SECRET: "MBiw2FOddg3Fs2Rm9NoDy10qufvJ4hzjmlQ1qwzV"
-      AWS_S3_ACCESS_KEY: "4SMIGZNCR8LM1LSUY1HU"
-      AWS_S3_REGION: "WAW3-2"
-
+      AWS_ACCESS_KEY_ID : "4SMIGZNCR8LM1LSUY1HU"
+      AWS_SECRET_ACCESS_KEY: "MBiw2FOddg3Fs2Rm9NoDy10qufvJ4hzjmlQ1qwzV"
+      AWS_REGION: "WAW3-2"
+      AWS_HTTPS: "YES"
+      AWS_VIRTUAL_HOSTING: "FALSE"
+      GDAL_HTTP_UNSAFESSL: "YES"
     resources:
       requests:
         memory: "3072Mi"


### PR DESCRIPTION
This adds an environment variable to the raster API settings that should tell it to resolve `s3://` URLs to CloudFerro S3.

Addresses

- https://github.com/EOEPCA/data-access/issues/75#issuecomment-2367427039