### PR TITLE
Applications to deploy openeo-geotrellis and its dependencies

### DIFF
--- a/argocd/eoepca/kustomization.yaml
+++ b/argocd/eoepca/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - iam
   - application-hub
   - resource-health
+  - openeo-geotrellis

--- a/argocd/eoepca/openeo-geotrellis/kustomization.yaml
+++ b/argocd/eoepca/openeo-geotrellis/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - openeo-geotrellis.yaml

--- a/argocd/eoepca/openeo-geotrellis/openeo-geotrellis.yaml
+++ b/argocd/eoepca/openeo-geotrellis/openeo-geotrellis.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openeo-geotrellis
+  namespace: argocd
+  labels:
+    eoepca/is-root-app: "true"
+    eoepca/app-name: openeo-geotrellis
+spec:
+  project: eoepca
+  source:
+    repoURL: https://github.com/EOEPCA/eoepca-plus
+    targetRevision: openeo-deployment
+    path: argocd/eoepca/openeo-geotrellis/parts
+  destination:
+    name: in-cluster
+    namespace: openeo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+      allowEmpty: true
+    syncOptions:
+      - Validate=true
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true

--- a/argocd/eoepca/openeo-geotrellis/parts/kustomization.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+  - openeo-geotrellis-zookeeper.yaml
+  - openeo-geotrellis-sparkoperator.yaml
+  - openeo-geotrellis-openeo.yaml
+

--- a/argocd/eoepca/openeo-geotrellis/parts/openeo-geotrellis-openeo.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/openeo-geotrellis-openeo.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openeo-geotrellis-openeo
+  namespace: argocd
+  labels:
+    eoepca/app-name: openeo-geotrellis-openeo
+spec:
+  # Ref. https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/
+  project: eoepca
+  sources:
+    - repoURL: https://artifactory.vgt.vito.be/artifactory/helm-charts
+      chart: sparkapplication
+      targetRevision: 0.14.9
+      helm:
+        releaseName: openeo-geotrellis-openeo
+        valueFiles:
+          - $values/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-openeo.yaml
+    - repoURL: https://github.com/EOEPCA/eoepca-plus
+      targetRevision: openeo-deployment
+      ref: values
+
+  destination:
+    name: in-cluster
+    namespace: openeo-geotrellis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - Validate=true
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true

--- a/argocd/eoepca/openeo-geotrellis/parts/openeo-geotrellis-sparkoperator.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/openeo-geotrellis-sparkoperator.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openeo-geotrellis-sparkoperator
+  namespace: argocd
+  labels:
+    eoepca/app-name: openeo-geotrellis-sparkoperator
+spec:
+  # Ref. https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/
+  project: eoepca
+  sources:
+    - repoURL: https://artifactory.vgt.vito.be/artifactory/helm-charts
+      chart: spark-operator
+      targetRevision: 2.0.2
+      helm:
+        releaseName: openeo-geotrellis-sparkoperator
+        valueFiles:
+          - $values/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-sparkoperator.yaml
+    - repoURL: https://github.com/EOEPCA/eoepca-plus
+      targetRevision: openeo-deployment
+      ref: values
+
+  destination:
+    name: in-cluster
+    namespace: openeo-geotrellis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - Validate=true
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true

--- a/argocd/eoepca/openeo-geotrellis/parts/openeo-geotrellis-zookeeper.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/openeo-geotrellis-zookeeper.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openeo-geotrellis-zookeeper
+  namespace: argocd
+  labels:
+    eoepca/app-name: openeo-geotrellis-zookeeper
+spec:
+  # Ref. https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/
+  project: eoepca
+  sources:
+    - repoURL: https://artifactory.vgt.vito.be/artifactory/helm-charts
+      chart: zookeeper
+      targetRevision: 11.1.6
+      helm:
+        releaseName: openeo-geotrellis-zookeeper
+        valueFiles:
+          - $values/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-zookeeper.yaml
+    - repoURL: https://github.com/EOEPCA/eoepca-plus
+      targetRevision: openeo-deployment
+      ref: values
+
+  destination:
+    name: in-cluster
+    namespace: openeo-geotrellis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - Validate=true
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true

--- a/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-openeo.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-openeo.yaml
@@ -1,0 +1,57 @@
+---
+image: vito-docker.artifactory.vgt.vito.be/openeo-geotrellis-kube
+imageVersion: latest
+sparkVersion: 3.2.0
+type: Java
+driver:
+  env:
+    KUBE: "true"
+    KUBE_OPENEO_API_PORT: "50001"
+    PYTHONPATH: $PYTHONPATH:/opt/tensorflow/python38/2.3.0/:/opt/openeo/lib/python3.8/site-packages/
+    ZOOKEEPERNODES: zookeeper.zookeeper.svc.cluster.local:2181
+  podSecurityContext:
+    fsGroup: 18585
+    fsGroupChangePolicy: Always
+executor:
+  env:
+    PYTHONPATH: $PYTHONPATH:/opt/tensorflow/python38/2.3.0/:/opt/openeo/lib/python3.8/site-packages/
+fileDependencies:
+  - local:///opt/layercatalog.json
+  - local:///opt/log4j2.xml
+jarDependencies:
+  - local:///opt/geotrellis-extensions-static.jar
+mainApplicationFile: local:///opt/openeo/lib64/python3.8/site-packages/openeogeotrellis/deploy/kube.py
+sparkConf:
+  spark.executorEnv.DRIVER_IMPLEMENTATION_PACKAGE: openeogeotrellis
+  spark.appMasterEnv.DRIVER_IMPLEMENTATION_PACKAGE: openeogeotrellis
+service:
+  enabled: true
+  port: 50001
+ha:
+  enabled: false
+rbac:
+  create: true
+  role:
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - create
+          - delete
+          - deletecollection
+          - list
+  serviceAccountDriver: openeo

--- a/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-sparkoperator.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-sparkoperator.yaml
@@ -1,0 +1,22 @@
+---
+image:
+  registry: vito-docker.artifactory.vgt.vito.be
+  repository: spark-operator
+  tag: "v1beta2-2.0.2-3.5.2"
+controller:
+  batchScheduler:
+    enable: true
+  podMonitor:
+    create: false
+  uiIngress:
+    enable: false
+  resources:
+    requests:
+      cpu: 200m
+webhook:
+  resources:
+    requests:
+      cpu: 300m
+spark:
+  jobNamespaces:
+    - ""

--- a/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-zookeeper.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-zookeeper.yaml
@@ -1,0 +1,9 @@
+---
+replicacount: 1
+autopurge:
+  purgeInterval: 1
+persistence:
+  enabled: false
+resources:
+  requests:
+    memory: "1024Mi"

--- a/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-zookeeper.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-zookeeper.yaml
@@ -1,9 +1,12 @@
 ---
+global:
+  storageClass: "managed-nfs-storage-retain"
 replicacount: 1
 autopurge:
   purgeInterval: 1
 persistence:
-  enabled: false
+  storageClass: "managed-nfs-storage-retain"
+  size: "5Gi"
 resources:
   requests:
     memory: "1024Mi"


### PR DESCRIPTION
This PR adds the necessary ArgoCD applications to deploy openeo-geotrellis together with Zookeeper and the spark-operator. This follows the docs on https://eoepca.readthedocs.io/projects/deploy/en/latest/eoepca/openeo-geotrellis/#helm-chart. 

There's no persistence yet for Zookeeper, as I wasn't sure if I could add that. Can easily be enabled if I have a `StorageClass` to use.

If there's any info missing, I'd be happy to provide anything necessary.