### PR TITLE
fix(eoapi): allow support chart to apply cert bundle to metrics server

### DIFF
--- a/argocd/eoepca/data-access/parts/app-data-access-core.yaml
+++ b/argocd/eoepca/data-access/parts/app-data-access-core.yaml
@@ -26,13 +26,13 @@ spec:
         releaseName: eoapi
         valueFiles:
           - $values/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
-    # - repoURL: https://devseed.com/eoapi-k8s/
-    #   chart: eoapi-support
-    #   targetRevision: 0.1.6
-    #   helm:
-    #     releaseName: eoapi-support
-    #     valueFiles:
-    #       - $values/argocd/eoepca/data-access/parts/values/values-eoapi-support.yaml
+    - repoURL: https://devseed.com/eoapi-k8s/
+      chart: eoapi-support
+      targetRevision: 0.1.8
+      helm:
+        releaseName: eoapi-support
+        valueFiles:
+          - $values/argocd/eoepca/data-access/parts/values/values-eoapi-support.yaml
     - repoURL: https://github.com/EOEPCA/eoepca-plus
       targetRevision: deploy-develop
       ref: values

--- a/argocd/eoepca/data-access/parts/values/values-eoapi-support.yaml
+++ b/argocd/eoepca/data-access/parts/values/values-eoapi-support.yaml
@@ -39,3 +39,11 @@ prometheus:
       storageClass: "managed-nfs-storage-retain"
       accessModes:
         - ReadWriteMany
+
+enableCaBundleFetch: true
+caBundleSecretName: "eoepca-ca-secret"
+metrics-server:
+  apiService:
+    caBundle: |
+      {{ include "eoapi-support.fetchCaBundle" . | indent 4 }}
+


### PR DESCRIPTION
Bump eoapi-support version and try new caBundle passthrough in order to not break `metric-server`