### PR TITLE
Add IAM client for use with STAC Manager

### DIFF
--- a/argocd/eoepca/data-access/parts/eoapi-iam.yaml
+++ b/argocd/eoepca/data-access/parts/eoapi-iam.yaml
@@ -21,6 +21,29 @@ spec:
     validRedirectUris:
       - '/*'
 ---
+apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+kind: Client
+metadata:
+  name: eoapi-develop
+spec:
+  providerConfigRef:
+    name: provider-keycloak
+  forProvider:
+    realmId: eoepca
+    name: eoapi-develop
+    accessType: PUBLIC
+    clientId: eoapi-develop
+    standardFlowEnabled: true
+    implicitFlowEnabled: false
+    directAccessGrantsEnabled: true # allow for now to simplify testing
+    serviceAccountsEnabled: false
+    oauth2DeviceAuthorizationGrantEnabled: true
+    rootUrl: https://stac-manager.develop.eoepca.org
+    webOrigins:
+      - '/*'
+    validRedirectUris:
+      - '/*'
+---
 apiVersion: role.keycloak.crossplane.io/v1alpha1
 kind: Role
 metadata: 


### PR DESCRIPTION
Adds IAM client for use with STAC Manager as requested in

- https://github.com/EOEPCA/resource-discovery/issues/132

This may require changes for the client to support the right auth flow or if the public URL of STAC Manager does not turn out as expected.