### PR TITLE
add missing dependencies jar to classpath

### DIFF
--- a/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-openeo.yaml
+++ b/argocd/eoepca/openeo-geotrellis/parts/values-openeo-geotrellis-openeo.yaml
@@ -213,6 +213,7 @@ ingress:
       secretName: openeo-geotrellis-openeo-sparkapplication-cert
 jarDependencies:
   - local:///opt/geotrellis-extensions-static.jar
+  - local:///opt/geotrellis-dependencies-static.jar
 mainApplicationFile: local:///opt/openeo/lib64/python3.8/site-packages/openeogeotrellis/deploy/kube.py
 sparkConf:
   spark.executorEnv.DRIVER_IMPLEMENTATION_PACKAGE: openeogeotrellis


### PR DESCRIPTION
Sync jobs fail with:

Server error: Exception during Spark execution: java.lang.ClassNotFoundException: geotrellis.raster.GridBounds