### PR TITLE
Add very basic stac-auth-proxy

### DIFF
--- a/argocd/eoepca/data-access/parts/kustomization.yaml
+++ b/argocd/eoepca/data-access/parts/kustomization.yaml
@@ -5,3 +5,8 @@ resources:
   - iam.yaml
   - route.yaml
   - eso-pgo.yaml
+
+configMapGenerator:
+  - name: stac-auth-proxy-filters
+    files:
+      - eoepca_filters.py=stac-auth-proxy/eoepca_filters.py

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -1,0 +1,16 @@
+import dataclasses
+
+from typing import Any
+
+
+@dataclasses.dataclass
+class CollectionsFilter:
+    async def __call__(self, context: dict[str, Any]) -> str:
+        return "1=1"
+
+
+@dataclasses.dataclass
+class ItemsFilter:
+    async def __call__(self, context: dict[str, Any]) -> str:
+        return "1=1"
+

--- a/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
+++ b/argocd/eoepca/data-access/parts/values/values-eoapi.yaml
@@ -109,3 +109,22 @@ eoapi-notifier:
               kind: Broker
               name: primary
               namespace: default
+
+stac-auth-proxy:
+  enabled: true
+  service:
+    port: 8080
+  env:
+    UPSTREAM_URL: "https://eoapi.develop.eoepca.org/stac"
+    OIDC_DISCOVERY_URL: "https://iam-auth.develop.eoepca.org/realms/eoepca/.well-known/openid-configuration"
+    COLLECTIONS_FILTER_CLS: stac_auth_proxy.eoepca_filters:CollectionsFilter
+    ITEMS_FILTER_CLS: stac_auth_proxy.eoepca_filters:ItemsFilter
+  extraVolumes:
+    - name: filters
+      configMap:
+        name: stac-auth-proxy-filters
+  extraVolumeMounts:
+    - name: filters
+      mountPath: /app/src/stac_auth_proxy/eoepca_filters.py
+      subPath: eoepca_filters.py
+      readOnly: true


### PR DESCRIPTION
* This enables [stac-auth-proxy](https://github.com/developmentseed/stac-auth-proxy) to handle access to the STAC API.
* Currently it only sets up the structure but does no actual filtering.
* It prepares [record-level-auth](https://developmentseed.org/stac-auth-proxy/user-guide/record-level-auth/) permission logic being implemented in `eoepca_filters.py`.