### PR TITLE
Fix OIDC typo: odicOrganisation -> oidcOrganisation

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -23,7 +23,7 @@ spec:
             apiTitle: "OpenEO ArgoWorkflows"
             apiDescription: "A K8S deployment of the openeo api for argoworkflows."
             oidcUrl: "https://edp-portal.eurac.edu/auth/realms/edp"
-            odicOrganisation: "eurac-keycloak"
+            oidcOrganisation: "eurac-keycloak"
             oidcPolicies: ""
             stacCatalogueUrl: "https://stac.eodc.eu/api/v1"
             workspaceRoot: "/user_workspaces"


### PR DESCRIPTION
Fixed typo in Helm values: odicOrganisation (missing 'c') -> oidcOrganisation.

The Helm chart maps these to environment variables:
- oidcUrl -> OIDC_URL (issuer)
- oidcOrganisation -> OIDC_ORGANISATION (id)

This should make the OIDC provider metadata return EURAC Keycloak values instead of EGI defaults.