### PR TITLE
Match Helm chart typo: use odicOrganisation

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -23,7 +23,7 @@ spec:
             apiTitle: "OpenEO ArgoWorkflows"
             apiDescription: "A K8S deployment of the openeo api for argoworkflows."
             oidcUrl: "https://edp-portal.eurac.edu/auth/realms/edp"
-            oidcOrganisation: "eurac-keycloak"
+            odicOrganisation: "eurac-keycloak"
             oidcPolicies: ""
             stacCatalogueUrl: "https://stac.eodc.eu/api/v1"
             workspaceRoot: "/user_workspaces"


### PR DESCRIPTION
The Helm chart template uses `.Values.global.env.odicOrganisation` (with typo).
We need to match this typo in our values until the chart is fixed.

This maps to OIDC_ORGANISATION environment variable which sets the provider ID.