### PR TITLE
fix: Add missing ingress-openeo.yaml to kustomization

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: openeo
 resources:
   - helm-openeo-argoworkflows.yaml
   - ingress-openeo.yaml
+  - ingress-openeo.yaml


### PR DESCRIPTION
The ingress-openeo.yaml file exists but wasn't included in the kustomization resources, causing the OpenEO API route to be missing. This prevents access to the deployed service at the configured URL.