### PR TITLE
fix: Remove duplicate ingress-openeo.yaml entry in kustomization

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/kustomization.yaml
@@ -6,4 +6,3 @@ namespace: openeo
 resources:
   - helm-openeo-argoworkflows.yaml
   - ingress-openeo.yaml
-  - ingress-openeo.yaml


### PR DESCRIPTION
Previous PR accidentally added the ingress entry twice. This causes kustomization to fail or create duplicate resources.