### PR TITLE
Fix OpenEO backend URL and OIDC configuration

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -19,6 +19,7 @@ spec:
             alembicDir: "/opt/openeo_argoworkflows_api/psql"
             apiDns: openeo-eurac.develop.eoepca.org
             apiTLS: true
+            apiUrl: "https://openeo-eurac.develop.eoepca.org/openeo/1.1.0"
             apiTitle: "OpenEO ArgoWorkflows"
             apiDescription: "A K8S deployment of the openeo api for argoworkflows."
             oidcUrl: "https://edp-portal.eurac.edu/auth/realms/edp"

--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -25,6 +25,38 @@ spec:
         # Allow CORS access
         - name: cors
           enable: true
+        # Fix URLs and OIDC configuration in response body
+        - name: serverless-post-function
+          enable: true
+          config:
+            phase: header_filter
+            functions:
+              - "return function(conf, ctx)
+                  local core = require('apisix.core')
+                  local ngx = ngx
+                  -- Store original body for rewriting
+                  ngx.ctx.api_ctx = ngx.ctx.api_ctx or {}
+                  ngx.ctx.api_ctx.need_body_rewrite = true
+                end"
+        - name: serverless-post-function
+          enable: true
+          config:
+            phase: body_filter
+            functions:
+              - "return function(conf, ctx)
+                  local ngx = ngx
+                  local ctx_api = ngx.ctx.api_ctx
+                  if ctx_api and ctx_api.need_body_rewrite and ngx.arg[1] then
+                    -- Fix localhost URLs
+                    local body = ngx.arg[1]
+                    body = string.gsub(body, 'http://127%.0%.0%.1:8000/openeo/1%.1%.0/', 'https://openeo-eurac.develop.eoepca.org/openeo/1.1.0/')
+                    -- Fix OIDC provider: replace EGI with EURAC Keycloak
+                    body = string.gsub(body, '\"id\":\"egi\"', '\"id\":\"eurac-keycloak\"')
+                    body = string.gsub(body, '\"issuer\":\"https://aai.egi.eu/auth/realms/egi\"', '\"issuer\":\"https://edp-portal.eurac.edu/auth/realms/edp\"')
+                    body = string.gsub(body, '\"title\":\"EGI Check%-in\"', '\"title\":\"EURAC Keycloak\"')
+                    ngx.arg[1] = body
+                  end
+                end"
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
## Problem
The OpenEO backend was returning localhost URLs (http://127.0.0.1:8000) in the /.well-known/openeo endpoint, causing CORS errors when the web editor tried to connect.

## Root Cause
After thorough comparison with the working EURAC inhouse setup, identified two missing configurations:
1. Missing `apiUrl` parameter in Helm values
2. Removed serverless-post-function plugins that rewrite URLs at ingress level

## Solution
This PR restores the working configuration matching the EURAC inhouse setup:

### 1. Helm Configuration (helm-openeo-argoworkflows.yaml)
- Added `apiUrl: "https://openeo-eurac.develop.eoepca.org/openeo/1.1.0"` parameter
- This configures the backend to use the correct external URL

### 2. APISIX Ingress Configuration (ingress-openeo.yaml)
- Restored serverless-post-function plugins with proper Lua syntax
- Plugins rewrite localhost URLs to external URLs in response body
- Plugins also fix OIDC provider configuration (EGI → EURAC Keycloak)

## Changes
- `argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml`: Added apiUrl parameter
- `argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml`: Restored URL rewriting plugins

## Testing
Configuration matches the working EURAC inhouse setup at /home/yadagale/eoepca-plus/eoepca-plus

## Expected Outcome
- Backend will return correct external URLs instead of localhost
- Web editor will be able to connect without CORS errors
- OIDC authentication will use EURAC Keycloak provider