### PR TITLE
fix(openeo): Use patched API image with EURAC Keycloak support

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -39,7 +39,7 @@ spec:
         image:
           repository: yuvraj1989/openeo-argoworkflows-api
           pullPolicy: Always
-          tag: "eurac-custom-oidc"
+          tag: "eurac-custom-oidc-v3"
 
         postgresql:
           enabled: true


### PR DESCRIPTION
## Summary

- Updates OpenEO API image tag from `eurac-custom-oidc` to `eurac-custom-oidc-v3`
- Fixes OIDC authentication to use EURAC Keycloak instead of EGI Check-in

## Problem

The current image tag `eurac-custom-oidc` points to the **executor** image, not the API image. The upstream `openeo-fastapi` library has the OIDC provider title and scopes **hardcoded** for EGI Check-in:

```python
Provider(
    id=self.settings.OIDC_ORGANISATION,
    title="EGI Check-in",  # HARDCODED
    issuer=self.settings.OIDC_URL,
    scopes=["openid", "email", "eduperson_entitlement", "eduperson_scoped_affiliation"],  # EGI-specific
    ...
)
```

This causes authentication to fail when using EURAC Keycloak because:
1. The provider title shows as "EGI Check-in" instead of "EURAC Keycloak"
2. EGI-specific scopes (`eduperson_entitlement`, `eduperson_scoped_affiliation`) are not supported by EURAC Keycloak

## Solution

The `eurac-custom-oidc-v3` image contains a patched `openeo-fastapi` with:
- OIDC provider title: "EURAC Keycloak" (instead of hardcoded "EGI Check-in")
- Standard OIDC scopes: `openid`, `email`, `profile` (instead of EGI-specific scopes)
- Additional redirect URLs for local testing

## Testing

This change has been tested on the EURAC in-house MicroK8s deployment where:
- ✅ OIDC authentication works with EURAC Keycloak
- ✅ OpenEO jobs can be submitted and executed
- ✅ Results can be downloaded successfully

## Test plan

- [ ] Verify ArgoCD syncs the new image
- [ ] Test OIDC authentication at https://openeo-eurac.develop.eoepca.org
- [ ] Verify credentials endpoint returns EURAC Keycloak instead of EGI Check-in