### PR TITLE
fix(openeo): Remove broken APISIX serverless-post-function plugins

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -26,38 +26,6 @@ spec:
         # Allow CORS access
         - name: cors
           enable: true
-        # Fix URLs and OIDC configuration in response body
-        - name: serverless-post-function
-          enable: true
-          config:
-            phase: header_filter
-            functions:
-              - "return function(conf, ctx)
-                  local core = require('apisix.core')
-                  local ngx = ngx
-                  -- Store original body for rewriting
-                  ngx.ctx.api_ctx = ngx.ctx.api_ctx or {}
-                  ngx.ctx.api_ctx.need_body_rewrite = true
-                end"
-        - name: serverless-post-function
-          enable: true
-          config:
-            phase: body_filter
-            functions:
-              - "return function(conf, ctx)
-                  local ngx = ngx
-                  local ctx_api = ngx.ctx.api_ctx
-                  if ctx_api and ctx_api.need_body_rewrite and ngx.arg[1] then
-                    -- Fix localhost URLs
-                    local body = ngx.arg[1]
-                    body = string.gsub(body, 'http://127%.0%.0%.1:8000/openeo/1%.1%.0/', 'https://openeo-eurac.develop.eoepca.org/openeo/1.1.0/')
-                    -- Fix OIDC provider: replace EGI with EURAC Keycloak
-                    body = string.gsub(body, '\"id\":\"egi\"', '\"id\":\"eurac-keycloak\"')
-                    body = string.gsub(body, '\"issuer\":\"https://aai.egi.eu/auth/realms/egi\"', '\"issuer\":\"https://edp-portal.eurac.edu/auth/realms/edp\"')
-                    body = string.gsub(body, '\"title\":\"EGI Check%-in\"', '\"title\":\"EURAC Keycloak\"')
-                    ngx.arg[1] = body
-                  end
-                end"
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
## Summary

Removes the broken APISIX serverless-post-function plugins that were causing the route to fail.

## Problem

APISIX reported a Lua syntax error:
```
"1: 'end' expected near '<eof>'"
```

This prevented the OpenEO route from being registered, making the endpoint unusable.

## Solution

Since PR #99 deployed the patched API image (`eurac-custom-oidc-v3`) that **natively returns EURAC Keycloak configuration**, the body rewriting plugins are no longer needed.

This PR:
- Removes the broken `serverless-post-function` plugins
- Keeps CORS plugin enabled
- Simplifies the ingress configuration

## Related

- Depends on PR #99 (already merged) which provides the patched API image

## Test plan

After merge:
1. Verify APISIX accepts the route (no more syntax errors)
2. Check credentials endpoint returns EURAC Keycloak:
   ```bash
   curl -s https://openeo-eurac.develop.eoepca.org/openeo/1.1.0/credentials/oidc | jq '.providers[0].title'
   # Expected: "EURAC Keycloak"
   ```
3. Test authentication via OpenEO Web Editor