### PR TITLE
fix(openeo): Remove broken APISIX serverless-post-function plugins

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -26,38 +26,6 @@ spec:
         # Allow CORS access
         - name: cors
           enable: true
-        # Fix URLs and OIDC configuration in response body
-        - name: serverless-post-function
-          enable: true
-          config:
-            phase: header_filter
-            functions:
-              - "return function(conf, ctx)
-                  local core = require('apisix.core')
-                  local ngx = ngx
-                  -- Store original body for rewriting
-                  ngx.ctx.api_ctx = ngx.ctx.api_ctx or {}
-                  ngx.ctx.api_ctx.need_body_rewrite = true
-                end"
-        - name: serverless-post-function
-          enable: true
-          config:
-            phase: body_filter
-            functions:
-              - "return function(conf, ctx)
-                  local ngx = ngx
-                  local ctx_api = ngx.ctx.api_ctx
-                  if ctx_api and ctx_api.need_body_rewrite and ngx.arg[1] then
-                    -- Fix localhost URLs
-                    local body = ngx.arg[1]
-                    body = string.gsub(body, 'http://127%.0%.0%.1:8000/openeo/1%.1%.0/', 'https://openeo-eurac.develop.eoepca.org/openeo/1.1.0/')
-                    -- Fix OIDC provider: replace EGI with EURAC Keycloak
-                    body = string.gsub(body, '\"id\":\"egi\"', '\"id\":\"eurac-keycloak\"')
-                    body = string.gsub(body, '\"issuer\":\"https://aai.egi.eu/auth/realms/egi\"', '\"issuer\":\"https://edp-portal.eurac.edu/auth/realms/edp\"')
-                    body = string.gsub(body, '\"title\":\"EGI Check%-in\"', '\"title\":\"EURAC Keycloak\"')
-                    ngx.arg[1] = body
-                  end
-                end"
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
## Summary

This PR re-applies the fix from PR #100 after PR #101 verified that CI test failures are unrelated to this change.

**Changes:**
- Removes the broken `serverless-post-function` plugins from the OpenEO APISIX route
- These plugins had Lua syntax errors causing APISIX to reject the route configuration
- The patched API image (`eurac-custom-oidc-v3` from PR #99) makes these plugins unnecessary

## Background

The APISIX serverless-post-function plugins contained Lua syntax errors:
```
"1: 'end' expected near '<eof>'"
```

This prevented APISIX from accepting the route configuration, blocking OpenEO authentication.

## Verification

PR #101 reverted PR #100's changes, and **tests still failed** with the same Keycloak connectivity errors. This confirms:

1. The test failures are caused by **Keycloak infrastructure issues** (`iam-auth.develop.eoepca.org` returning 404/SSL errors)
2. Our changes to remove the broken APISIX plugins are **NOT the cause** of test failures

## Test Plan

- [x] Verified APISIX accepts the route configuration without the broken plugins
- [x] Confirmed test failures persist even with plugins reverted (PR #101)
- [ ] Tests will pass once Keycloak infrastructure is restored