### PR TITLE
[stac-auth-proxy] buildout filter logic

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -1,0 +1,19 @@
+name: Run Unit Tests
+
+on:
+  push:
+
+jobs:
+  stac-auth-proxy-filters:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run pytest
+        working-directory: argocd/eoepca/data-access/parts/stac-auth-proxy
+        run: uv run --with pytest,pytest-asyncio,cql2 pytest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv/
 k.yaml
 *.crt
 *.key
+*.pyc

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -58,31 +58,27 @@ def get_cql2_filters(
             else:
                 for name in group_names:
                     # We expect group names in the format of '/dss/{group_prefix}(-ro)?'
-                    if any(
-                        (
-                            # Groups should begin with /dss/
-                            not name.startswith("/dss/"),
-                            # Collection IDs should contain '-dss-'
-                            "-dss-" not in name,
-                            # Ignore manager groups
-                            name.endswith("-mgr"),
-                        )
-                    ):
-                        logger.debug(
-                            "Ignoring group name '%s' as it does not match expected format",
-                            name,
-                        )
+                    if not name.startswith("/dss/"):
+                        logger.debug("Ignoring group '%s': missing /dss/ prefix", name)
                         continue
 
-                    # Strip the '/dss/' prefix
-                    name = name[len("/dss/") :]
+                    # Strip the '/dss/' prefix, then validate the remainder
+                    group_id = name[len("/dss/"):]
 
-                    if name.endswith("-ro"):
+                    if "-dss-" not in group_id:
+                        logger.debug("Ignoring group '%s': missing -dss- infix", name)
+                        continue
+
+                    if group_id.endswith("-mgr"):
+                        logger.debug("Ignoring group '%s': manager group", name)
+                        continue
+
+                    if group_id.endswith("-ro"):
                         if not is_write:
-                            prefixes.add(name[: -len("-ro")])
+                            prefixes.add(group_id[:-len("-ro")])
                         # else: skip — read-only groups grant no write access
                     else:
-                        prefixes.add(name)
+                        prefixes.add(group_id)
         else:
             logger.warning("No 'groups' claim found in token")
 

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -1,16 +1,113 @@
+from typing import Any, Literal, Optional
 import dataclasses
+import logging
 
-from typing import Any
+logger = logging.getLogger(__name__)
+
+
+"""
+Rules:
+
+- Public Collections: Any collection without a '.' in the ID is considered "public"
+
+"""
+
+
+def get_cql2_filters(
+    *,
+    collection_prop: Literal["id", "collection"],
+    is_write: bool,
+    token: Optional[dict[str, Any]],
+) -> str:
+    """
+    Extract collection prefixes from a user's token claims.
+
+    Groups are expected in one of the following formats:
+    - /dss/{group_id}          — grants read and write access
+    - /dss/{group_id}-ro       — grants read-only access (ignored during write checks)
+
+    :return: A set of collection prefixes that the user has access to.
+    """
+    policies = set()
+
+    # Public Collections: Any collection without a prefix (ie no '.' in the ID) is considered "public"
+    policies.add(f"{collection_prop} NOT LIKE '%.%'")
+
+    # Authenticated users can access
+    if token:
+        prefixes = set()
+
+        # Users can read/write any collection prefixed with their username
+        if user_id := token.get("preferred_username"):
+            prefixes.add(user_id)
+        else:
+            logger.warning("No 'preferred_username' claim found in token")
+
+        if group_names := token.get("groups"):
+            if not isinstance(group_names, list):
+                logger.warning(
+                    "Expected 'groups' claim to be a list, got %s", type(group_names)
+                )
+            else:
+                for name in group_names:
+                    # We expect group names in the format of '/dss/{group_prefix}(-ro)?'
+                    if any(
+                        (
+                            # Groups should begin with /dss/
+                            not name.startswith("/dss/"),
+                            # Collection IDs should contain '-dss-'
+                            "-dss-" not in name,
+                            # Ignore manager groups
+                            name.endswith("-mgr"),
+                        )
+                    ):
+                        logger.debug(
+                            "Ignoring group name '%s' as it does not match expected format",
+                            name,
+                        )
+                        continue
+
+                    # Strip the '/dss/' prefix
+                    name = name[len("/dss/") :]
+
+                    if name.endswith("-ro"):
+                        if not is_write:
+                            prefixes.add(name[: -len("-ro")])
+                        # else: skip — read-only groups grant no write access
+                    else:
+                        prefixes.add(name)
+        else:
+            logger.warning("No 'groups' claim found in token")
+
+        for prefix in prefixes:
+            policies.add(f"{collection_prop} LIKE '{prefix}.%'")
+
+    # Combine policies with OR, as any policy being true should allow access
+    return " OR ".join(policies)
 
 
 @dataclasses.dataclass
 class CollectionsFilter:
+
     async def __call__(self, context: dict[str, Any]) -> str:
-        return "1=1"
+        token = context.get("payload")
+        if not token:
+            logger.debug("No token found in context, unauthenticated access")
+        return get_cql2_filters(
+            collection_prop="id",
+            is_write=False,  # TODO: Support write policies
+            token=token,
+        )
 
 
 @dataclasses.dataclass
 class ItemsFilter:
     async def __call__(self, context: dict[str, Any]) -> str:
-        return "1=1"
-
+        token = context.get("payload")
+        if not token:
+            logger.debug("No token found in context, unauthenticated access")
+        return get_cql2_filters(
+            collection_prop="collection",
+            is_write=False,  # TODO: Support write policies
+            token=token,
+        )

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -26,6 +26,10 @@ def get_cql2_filters(
     - /dss/{group_id}          — grants read and write access
     - /dss/{group_id}-ro       — grants read-only access (ignored during write checks)
 
+    :param collection_prop: The property name to filter on (e.g., "id" for collections, "collection" for items).
+    :param is_write: Whether to generate filters for write access (True) or read access (False).
+    :param token: The user's authentication token containing claims. None for unauthenticated users.
+
     :return: A set of collection prefixes that the user has access to.
     """
     policies = set()

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -29,15 +29,16 @@ def get_cql2_filters(
     policies.add("1=0")
 
     # Public Collections: Any collection without a prefix (ie no '.' in the ID) is considered "public"
-    policies.add(f"{collection_prop} NOT LIKE '%.%'")
+    if not is_write:
+        policies.add(f"{collection_prop} NOT LIKE '%.%'")
 
-    # Authenticated users can access
+    # Private Collections: Authenticated users can access collections based on their username and group memberships
     if token:
-        prefixes = set()
+        allowed_prefixes = set()
 
         # Users can read/write any collection prefixed with their username
         if user_id := token.get("preferred_username"):
-            prefixes.add(user_id)
+            allowed_prefixes.add(user_id)
         else:
             logger.warning("No 'preferred_username' claim found in token")
 
@@ -69,14 +70,14 @@ def get_cql2_filters(
 
                     if group_id.endswith("-ro"):
                         if not is_write:
-                            prefixes.add(group_id[: -len("-ro")])
+                            allowed_prefixes.add(group_id[: -len("-ro")])
                         # else: skip — read-only groups grant no write access
                     else:
-                        prefixes.add(group_id)
+                        allowed_prefixes.add(group_id)
         else:
             logger.warning("No 'groups' claim found in token")
 
-        for prefix in prefixes:
+        for prefix in allowed_prefixes:
             if not _SAFE_PREFIX_RE.match(prefix):
                 logger.warning("Ignoring prefix with unsafe characters: %r", prefix)
                 continue
@@ -84,6 +85,28 @@ def get_cql2_filters(
 
     # Combine policies with OR, as any policy being true should allow access
     return " OR ".join(policies)
+
+
+def is_write_request(req: dict) -> bool:
+    """
+    Determine if the incoming request is a write operation based on its method and path.
+
+    Read operations:
+    - GET, HEAD, OPTIONS — always reads
+    - POST to /search — this is a read (STAC uses POST for complex search queries)
+
+    Write operations:
+    - POST (to non-search endpoints, e.g. creating items/collections)
+    - PUT, PATCH, DELETE
+    """
+    method = req["method"].upper()
+    path = req["path"]
+
+    if method in ("GET", "HEAD", "OPTIONS"):
+        return False
+    if method == "POST" and path.rstrip("/").endswith("/search"):
+        return False
+    return True  # POST (non-search), PUT, PATCH, DELETE
 
 
 @dataclasses.dataclass
@@ -94,7 +117,7 @@ class CollectionsFilter:
             logger.debug("No token found in context, unauthenticated access")
         return get_cql2_filters(
             collection_prop="id",
-            is_write=False,  # TODO: Support write policies
+            is_write=is_write_request(context["req"]),
             token=token,
         )
 
@@ -107,6 +130,6 @@ class ItemsFilter:
             logger.debug("No token found in context, unauthenticated access")
         return get_cql2_filters(
             collection_prop="collection",
-            is_write=False,  # TODO: Support write policies
+            is_write=is_write_request(context["req"]),
             token=token,
         )

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -25,6 +25,9 @@ def get_cql2_filters(
     """
     policies = set()
 
+    # IMPORTANT: We start with a policy that denies all access, then add exceptions below
+    policies.add("1=0")
+
     # Public Collections: Any collection without a prefix (ie no '.' in the ID) is considered "public"
     policies.add(f"{collection_prop} NOT LIKE '%.%'")
 

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -1,8 +1,11 @@
 from typing import Any, Literal, Optional
 import dataclasses
 import logging
+import re
 
 logger = logging.getLogger(__name__)
+
+_SAFE_PREFIX_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 
 """
@@ -84,6 +87,11 @@ def get_cql2_filters(
             logger.warning("No 'groups' claim found in token")
 
         for prefix in prefixes:
+            if not _SAFE_PREFIX_RE.match(prefix):
+                logger.warning(
+                    "Ignoring prefix with unsafe characters: %r", prefix
+                )
+                continue
             policies.add(f"{collection_prop} LIKE '{prefix}.%'")
 
     # Combine policies with OR, as any policy being true should allow access

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -25,9 +25,6 @@ def get_cql2_filters(
     """
     policies = set()
 
-    # IMPORTANT: We start with a policy that denies all access, then add exceptions below
-    policies.add("1=0")
-
     # Public Collections: Any collection without a prefix (ie no '.' in the ID) is considered "public"
     if not is_write:
         policies.add(f"{collection_prop} NOT LIKE '%.%'")
@@ -84,7 +81,8 @@ def get_cql2_filters(
             policies.add(f"{collection_prop} LIKE '{prefix}.%'")
 
     # Combine policies with OR, as any policy being true should allow access
-    return " OR ".join(policies)
+    # If no policies, return a filter that denies all access
+    return " OR ".join(policies) or "1=0"
 
 
 def is_write_request(req: dict) -> bool:

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -1,8 +1,11 @@
 from typing import Any, Literal, Optional
 import dataclasses
 import logging
+import re
 
 logger = logging.getLogger(__name__)
+
+_SAFE_PREFIX_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 
 def get_cql2_filters(
@@ -83,6 +86,11 @@ def get_cql2_filters(
             logger.warning("No 'groups' claim found in token")
 
         for prefix in sorted(allowed_prefixes):
+            if not _SAFE_PREFIX_RE.match(prefix):
+                logger.warning(
+                    "Skipping unsafe prefix '%s' derived from token claims", prefix
+                )
+                continue
             policies.append(
                 {"op": "like", "args": [{"property": collection_prop}, f"{prefix}.%"]}
             )

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -8,14 +8,6 @@ logger = logging.getLogger(__name__)
 _SAFE_PREFIX_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 
-"""
-Rules:
-
-- Public Collections: Any collection without a '.' in the ID is considered "public"
-
-"""
-
-
 def get_cql2_filters(
     *,
     collection_prop: Literal["id", "collection"],
@@ -24,10 +16,6 @@ def get_cql2_filters(
 ) -> str:
     """
     Extract collection prefixes from a user's token claims.
-
-    Groups are expected in one of the following formats:
-    - /dss/{group_id}          — grants read and write access
-    - /dss/{group_id}-ro       — grants read-only access (ignored during write checks)
 
     :param collection_prop: The property name to filter on (e.g., "id" for collections, "collection" for items).
     :param is_write: Whether to generate filters for write access (True) or read access (False).
@@ -51,6 +39,9 @@ def get_cql2_filters(
             logger.warning("No 'preferred_username' claim found in token")
 
         if group_names := token.get("groups"):
+            # Groups are expected in one of the following formats:
+            # - /dss/{group_id}          — grants read and write access
+            # - /dss/{group_id}-ro       — grants read-only access (ignored during write checks)
             if not isinstance(group_names, list):
                 logger.warning(
                     "Expected 'groups' claim to be a list, got %s", type(group_names)
@@ -63,7 +54,7 @@ def get_cql2_filters(
                         continue
 
                     # Strip the '/dss/' prefix, then validate the remainder
-                    group_id = name[len("/dss/"):]
+                    group_id = name[len("/dss/") :]
 
                     if "-dss-" not in group_id:
                         logger.debug("Ignoring group '%s': missing -dss- infix", name)
@@ -75,7 +66,7 @@ def get_cql2_filters(
 
                     if group_id.endswith("-ro"):
                         if not is_write:
-                            prefixes.add(group_id[:-len("-ro")])
+                            prefixes.add(group_id[: -len("-ro")])
                         # else: skip — read-only groups grant no write access
                     else:
                         prefixes.add(group_id)
@@ -84,9 +75,7 @@ def get_cql2_filters(
 
         for prefix in prefixes:
             if not _SAFE_PREFIX_RE.match(prefix):
-                logger.warning(
-                    "Ignoring prefix with unsafe characters: %r", prefix
-                )
+                logger.warning("Ignoring prefix with unsafe characters: %r", prefix)
                 continue
             policies.add(f"{collection_prop} LIKE '{prefix}.%'")
 
@@ -96,7 +85,6 @@ def get_cql2_filters(
 
 @dataclasses.dataclass
 class CollectionsFilter:
-
     async def __call__(self, context: dict[str, Any]) -> str:
         token = context.get("payload")
         if not token:

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/eoepca_filters.py
@@ -1,33 +1,41 @@
 from typing import Any, Literal, Optional
 import dataclasses
 import logging
-import re
 
 logger = logging.getLogger(__name__)
-
-_SAFE_PREFIX_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 
 def get_cql2_filters(
     *,
     collection_prop: Literal["id", "collection"],
     is_write: bool,
-    token: Optional[dict[str, Any]],
-) -> str:
+    token: Optional[dict],
+) -> dict:
     """
-    Extract collection prefixes from a user's token claims.
+    Build a CQL2-JSON filter expression based on a user's token claims.
+
+    Returns a CQL2-JSON dict (not CQL2-text) so that user-supplied values are
+    always in the value position of a structured expression, avoiding any
+    possibility of CQL2 injection.
 
     :param collection_prop: The property name to filter on (e.g., "id" for collections, "collection" for items).
     :param is_write: Whether to generate filters for write access (True) or read access (False).
     :param token: The user's authentication token containing claims. None for unauthenticated users.
 
-    :return: A set of collection prefixes that the user has access to.
+    :return: A CQL2-JSON filter dict that restricts access based on the user's claims.
     """
-    policies = set()
+    policies: list[dict] = []
 
     # Public Collections: Any collection without a prefix (ie no '.' in the ID) is considered "public"
     if not is_write:
-        policies.add(f"{collection_prop} NOT LIKE '%.%'")
+        policies.append(
+            {
+                "op": "not",
+                "args": [
+                    {"op": "like", "args": [{"property": collection_prop}, "%.%"]}
+                ],
+            }
+        )
 
     # Private Collections: Authenticated users can access collections based on their username and group memberships
     if token:
@@ -74,15 +82,18 @@ def get_cql2_filters(
         else:
             logger.warning("No 'groups' claim found in token")
 
-        for prefix in allowed_prefixes:
-            if not _SAFE_PREFIX_RE.match(prefix):
-                logger.warning("Ignoring prefix with unsafe characters: %r", prefix)
-                continue
-            policies.add(f"{collection_prop} LIKE '{prefix}.%'")
+        for prefix in sorted(allowed_prefixes):
+            policies.append(
+                {"op": "like", "args": [{"property": collection_prop}, f"{prefix}.%"]}
+            )
 
     # Combine policies with OR, as any policy being true should allow access
     # If no policies, return a filter that denies all access
-    return " OR ".join(policies) or "1=0"
+    if not policies:
+        return {"op": "=", "args": [1, 0]}
+    if len(policies) == 1:
+        return policies[0]
+    return {"op": "or", "args": policies}
 
 
 def is_write_request(req: dict) -> bool:
@@ -109,7 +120,8 @@ def is_write_request(req: dict) -> bool:
 
 @dataclasses.dataclass
 class CollectionsFilter:
-    async def __call__(self, context: dict[str, Any]) -> str:
+
+    async def __call__(self, context: dict) -> dict:
         token = context.get("payload")
         if not token:
             logger.debug("No token found in context, unauthenticated access")
@@ -122,7 +134,8 @@ class CollectionsFilter:
 
 @dataclasses.dataclass
 class ItemsFilter:
-    async def __call__(self, context: dict[str, Any]) -> str:
+
+    async def __call__(self, context: dict) -> dict:
         token = context.get("payload")
         if not token:
             logger.debug("No token found in context, unauthenticated access")

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
@@ -346,6 +346,7 @@ class TestCollectionsFilter:
         """Usernames with unsafe characters must not be interpolated into CQL2."""
         token = {"preferred_username": username}
         filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
+        print("Generated filter:", filt)
         assert cql2_matches(
             filt, {"id": "public"}
         ), "public access should still work with unsafe username"

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
@@ -191,6 +191,52 @@ class TestCollectionsFilter:
         ), "public access should work without groups claim"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "username",
+        [
+            pytest.param("' OR 1=1 --", id="sql-injection-style"),
+            pytest.param("alice'bob", id="embedded-single-quote"),
+            pytest.param("alice.bob", id="dot-in-username"),
+            pytest.param("alice bob", id="space-in-username"),
+        ],
+    )
+    async def test_unsafe_username_is_rejected(self, username):
+        """Usernames with unsafe characters must not be interpolated into CQL2."""
+        token = {"preferred_username": username}
+        filt = await CollectionsFilter()({"payload": token})
+        # Should only contain the public-collection policy, no user prefix
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public access should still work with unsafe username"
+        assert not cql2_matches(
+            filt, {"id": f"{username}.data"}
+        ), f"unsafe username {username!r} should not produce a filter granting access"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "group,derived_prefix",
+        [
+            pytest.param("/dss/org-dss-t'eam", "org-dss-t'eam", id="single-quote"),
+            pytest.param("/dss/org-dss-t eam", "org-dss-t eam", id="space"),
+            pytest.param(
+                "/dss/' OR 1=1-dss- --",
+                "' OR 1=1-dss- --",
+                id="cql2-injection",
+            ),
+        ],
+    )
+    async def test_unsafe_group_prefix_is_rejected(self, group, derived_prefix):
+        """Group names that yield unsafe prefixes must not be interpolated into CQL2."""
+        token = {"preferred_username": "alice", "groups": [group]}
+        filt = await CollectionsFilter()({"payload": token})
+        assert not cql2_matches(
+            filt, {"id": f"{derived_prefix}.data"}
+        ), f"unsafe group {group!r} should not produce a filter granting access"
+        assert cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "username-based access should still work despite unsafe group"
+
+    @pytest.mark.asyncio
     async def test_empty_groups_list_grants_no_group_access(self):
         """An empty groups list contributes no extra collection prefixes."""
         token = {"preferred_username": "alice", "groups": []}

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
@@ -1,0 +1,247 @@
+import pytest
+from cql2 import Expr
+
+from eoepca_filters import CollectionsFilter, ItemsFilter
+
+
+def cql2_matches(cql2_text: str, item: dict) -> bool:
+    """Parse a CQL2-text expression and test it against an item dict."""
+    expr = Expr(cql2_text)
+    expr.validate()
+    return expr.matches(item)
+
+
+class TestCollectionsFilter:
+    """CollectionsFilter generates CQL2 filters matching on the 'id' property."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_allows_public_collections(self):
+        """A collection without a '.' in the ID is public and visible without authentication."""
+        filt = await CollectionsFilter()({"payload": None})
+        assert cql2_matches(
+            filt, {"id": "sentinel-2"}
+        ), "public collection 'sentinel-2' should be visible without authentication"
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_denies_prefixed_collections(self):
+        """A collection with a '.' prefix (e.g. 'alice.data') requires authentication."""
+        filt = await CollectionsFilter()({"payload": None})
+        assert not cql2_matches(
+            filt, {"id": "alice.my-data"}
+        ), "prefixed collection 'alice.my-data' should not be visible without authentication"
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_denies_deeply_prefixed_collections(self):
+        """A collection with multiple '.' separators (e.g. 'org.dept.data') is also denied."""
+        filt = await CollectionsFilter()({"payload": None})
+        assert not cql2_matches(
+            filt, {"id": "org.dept.data"}
+        ), "deeply prefixed collection 'org.dept.data' should not be visible without authentication"
+
+    @pytest.mark.asyncio
+    async def test_missing_payload_treated_as_unauthenticated(self):
+        """A context dict without a 'payload' key is treated as unauthenticated."""
+        filt = await CollectionsFilter()({})
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public collection should be visible when payload key is missing"
+        assert not cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "prefixed collection should not be visible when payload key is missing"
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_can_access_own_prefixed_collections(self):
+        """The preferred_username claim grants access to '{username}.*' collections."""
+        token = {"preferred_username": "alice"}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "alice.my-data"}
+        ), "user 'alice' should be able to access her own prefixed collection 'alice.my-data'"
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_cannot_access_other_users_collections(self):
+        """A user cannot access collections prefixed with another user's name."""
+        token = {"preferred_username": "alice"}
+        filt = await CollectionsFilter()({"payload": token})
+        assert not cql2_matches(
+            filt, {"id": "bob.my-data"}
+        ), "user 'alice' should not be able to access 'bob.my-data'"
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_retains_public_access(self):
+        """Authentication does not revoke access to public collections."""
+        token = {"preferred_username": "alice"}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "sentinel-2"}
+        ), "authenticated user should still see public collection 'sentinel-2'"
+
+    @pytest.mark.asyncio
+    async def test_token_without_username_only_gets_public_access(self):
+        """If preferred_username is missing, only public collections are visible."""
+        token: dict = {}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public collection should be visible even without preferred_username"
+        assert not cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "prefixed collection should not be visible without preferred_username"
+
+    @pytest.mark.asyncio
+    async def test_rw_group_grants_read_access_to_group_prefix(self):
+        """A /dss/{prefix} group grants read access to '{prefix}.*' collections."""
+        token = {"preferred_username": "alice", "groups": ["/dss/org-dss-team"]}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "org-dss-team.dataset"}
+        ), "rw group '/dss/org-dss-team' should grant access to 'org-dss-team.dataset'"
+
+    @pytest.mark.asyncio
+    async def test_rw_group_does_not_grant_access_to_other_prefixes(self):
+        """A group only grants access to its own prefix, not unrelated prefixes."""
+        token = {"preferred_username": "alice", "groups": ["/dss/org-dss-team"]}
+        filt = await CollectionsFilter()({"payload": token})
+        assert not cql2_matches(
+            filt, {"id": "other-dss-org.dataset"}
+        ), "group '/dss/org-dss-team' should not grant access to 'other-dss-org.dataset'"
+
+    @pytest.mark.asyncio
+    async def test_ro_group_grants_read_access(self):
+        """A /dss/{prefix}-ro group grants read access to '{prefix}.*' collections."""
+        token = {"preferred_username": "alice", "groups": ["/dss/org-dss-shared-ro"]}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "org-dss-shared.dataset"}
+        ), "ro group '/dss/org-dss-shared-ro' should grant read access to 'org-dss-shared.dataset'"
+
+    @pytest.mark.asyncio
+    async def test_ro_group_public_still_visible(self):
+        """Public collections remain visible alongside read-only group access."""
+        token = {"preferred_username": "alice", "groups": ["/dss/org-dss-shared-ro"]}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "public-data"}
+        ), "public collection 'public-data' should remain visible with ro group membership"
+
+    @pytest.mark.asyncio
+    async def test_mixed_rw_and_ro_groups_both_grant_read_access(self):
+        """Both rw and ro groups contribute collection prefixes during read access."""
+        token = {
+            "preferred_username": "alice",
+            "groups": ["/dss/proj-dss-alpha", "/dss/proj-dss-beta-ro"],
+        }
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "proj-dss-alpha.data"}
+        ), "rw group should grant read access to 'proj-dss-alpha.data'"
+        assert cql2_matches(
+            filt, {"id": "proj-dss-beta.data"}
+        ), "ro group should also grant read access to 'proj-dss-beta.data'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "group",
+        [
+            pytest.param("/other/org-dss-team", id="wrong-prefix"),
+            pytest.param("/dss/org-team", id="missing-dss-infix"),
+            pytest.param("/dss/org-dss-team-mgr", id="manager-group"),
+            pytest.param("org-dss-team", id="no-leading-slash"),
+        ],
+    )
+    async def test_invalid_group_format_grants_no_extra_access(self, group):
+        """Groups that don't match '/dss/{name-with-dss-infix}' are silently ignored."""
+        token = {"preferred_username": "alice", "groups": [group]}
+        filt = await CollectionsFilter()({"payload": token})
+        assert not cql2_matches(
+            filt, {"id": "org-dss-team.data"}
+        ), f"invalid group '{group}' should not grant access to 'org-dss-team.data'"
+        assert cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "username-based access should still work despite invalid group"
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public access should still work despite invalid group"
+
+    @pytest.mark.asyncio
+    async def test_groups_claim_not_a_list_is_ignored(self):
+        """If the 'groups' claim is a string instead of a list, it is ignored gracefully."""
+        token = {"preferred_username": "alice", "groups": "not-a-list"}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public access should work when groups claim is malformed"
+        assert cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "username-based access should work when groups claim is malformed"
+        assert not cql2_matches(
+            filt, {"id": "not-a-list.data"}
+        ), "malformed groups string should not be treated as a collection prefix"
+
+    @pytest.mark.asyncio
+    async def test_no_groups_claim_still_allows_username_access(self):
+        """A token without a 'groups' claim still grants username-based access."""
+        token = {"preferred_username": "bob"}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "bob.data"}
+        ), "user 'bob' should access 'bob.data' even without any groups claim"
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public access should work without groups claim"
+
+    @pytest.mark.asyncio
+    async def test_empty_groups_list_grants_no_group_access(self):
+        """An empty groups list contributes no extra collection prefixes."""
+        token = {"preferred_username": "alice", "groups": []}
+        filt = await CollectionsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public access should work with empty groups list"
+        assert cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "username-based access should work with empty groups list"
+        assert not cql2_matches(
+            filt, {"id": "org-dss-team.data"}
+        ), "empty groups list should not grant access to any group-prefixed collection"
+
+
+class TestItemsFilter:
+    """ItemsFilter generates CQL2 filters matching on the 'collection' property."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_allows_items_in_public_collections(self):
+        """Items in public collections (no '.' in collection name) are visible without auth."""
+        filt = await ItemsFilter()({"payload": None})
+        assert cql2_matches(
+            filt, {"collection": "sentinel-2"}
+        ), "item in public collection 'sentinel-2' should be visible without authentication"
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_denies_items_in_prefixed_collections(self):
+        """Items in prefixed collections require authentication."""
+        filt = await ItemsFilter()({"payload": None})
+        assert not cql2_matches(
+            filt, {"collection": "alice.my-data"}
+        ), "item in prefixed collection 'alice.my-data' should not be visible without authentication"
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_can_access_own_and_group_items(self):
+        """Authenticated users can access items in username-prefixed and group collections."""
+        token = {
+            "preferred_username": "alice",
+            "groups": ["/dss/org-dss-shared"],
+        }
+        filt = await ItemsFilter()({"payload": token})
+        assert cql2_matches(
+            filt, {"collection": "alice.data"}
+        ), "user 'alice' should access items in her own collection 'alice.data'"
+        assert cql2_matches(
+            filt, {"collection": "org-dss-shared.data"}
+        ), "group membership should grant access to items in 'org-dss-shared.data'"
+        assert cql2_matches(
+            filt, {"collection": "public"}
+        ), "authenticated user should still access items in public collections"
+        assert not cql2_matches(
+            filt, {"collection": "bob.data"}
+        ), "user 'alice' should not access items in 'bob.data'"

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
@@ -1,7 +1,11 @@
 import pytest
 from cql2 import Expr
 
-from eoepca_filters import CollectionsFilter, ItemsFilter
+from eoepca_filters import CollectionsFilter, ItemsFilter, is_write_request
+
+# Reusable request context fragments
+_READ_REQ = {"method": "GET", "path": "/collections"}
+_WRITE_REQ = {"method": "POST", "path": "/collections"}
 
 
 def cql2_matches(cql2_text: str, item: dict) -> bool:
@@ -11,37 +15,89 @@ def cql2_matches(cql2_text: str, item: dict) -> bool:
     return expr.matches(item)
 
 
+class TestIsWriteRequest:
+    """is_write_request classifies HTTP requests as read or write."""
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            pytest.param("GET", id="GET"),
+            pytest.param("HEAD", id="HEAD"),
+            pytest.param("OPTIONS", id="OPTIONS"),
+        ],
+    )
+    def test_safe_methods_are_reads(self, method):
+        """GET, HEAD, and OPTIONS are always read operations."""
+        assert not is_write_request({"method": method, "path": "/collections"})
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            pytest.param("/search", id="search"),
+            pytest.param("/search/", id="search-trailing-slash"),
+        ],
+    )
+    def test_post_to_search_is_read(self, path):
+        """POST to /search (with or without trailing slash) is a read."""
+        assert not is_write_request({"method": "POST", "path": path})
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            pytest.param("POST", id="POST"),
+            pytest.param("PUT", id="PUT"),
+            pytest.param("PATCH", id="PATCH"),
+            pytest.param("DELETE", id="DELETE"),
+        ],
+    )
+    def test_mutating_methods_are_writes(self, method):
+        """POST (non-search), PUT, PATCH, and DELETE are write operations."""
+        assert is_write_request({"method": method, "path": "/collections"})
+
+    def test_post_to_items_endpoint_is_write(self):
+        """POST to an items endpoint (creating an item) is a write."""
+        assert is_write_request({"method": "POST", "path": "/collections/my-col/items"})
+
+    def test_case_insensitive_method(self):
+        """HTTP methods are matched case-insensitively."""
+        assert not is_write_request({"method": "get", "path": "/collections"})
+        assert is_write_request({"method": "post", "path": "/collections"})
+
+
 class TestCollectionsFilter:
     """CollectionsFilter generates CQL2 filters matching on the 'id' property."""
 
-    @pytest.mark.asyncio
-    async def test_unauthenticated_allows_public_collections(self):
-        """A collection without a '.' in the ID is public and visible without authentication."""
-        filt = await CollectionsFilter()({"payload": None})
-        assert cql2_matches(
-            filt, {"id": "sentinel-2"}
-        ), "public collection 'sentinel-2' should be visible without authentication"
+    # --- Unauthenticated access ---
 
     @pytest.mark.asyncio
-    async def test_unauthenticated_denies_prefixed_collections(self):
-        """A collection with a '.' prefix (e.g. 'alice.data') requires authentication."""
-        filt = await CollectionsFilter()({"payload": None})
-        assert not cql2_matches(
-            filt, {"id": "alice.my-data"}
-        ), "prefixed collection 'alice.my-data' should not be visible without authentication"
+    @pytest.mark.parametrize(
+        "collection_id,expected",
+        [
+            pytest.param("sentinel-2", True, id="public-allowed"),
+            pytest.param("alice.my-data", False, id="prefixed-denied"),
+            pytest.param("org.dept.data", False, id="deep-prefix-denied"),
+        ],
+    )
+    async def test_unauthenticated_read_access(self, collection_id, expected):
+        """Unauthenticated reads allow public collections but deny prefixed ones."""
+        filt = await CollectionsFilter()({"payload": None, "req": _READ_REQ})
+        assert cql2_matches(filt, {"id": collection_id}) == expected
 
     @pytest.mark.asyncio
-    async def test_unauthenticated_denies_deeply_prefixed_collections(self):
-        """A collection with multiple '.' separators (e.g. 'org.dept.data') is also denied."""
-        filt = await CollectionsFilter()({"payload": None})
+    async def test_unauthenticated_write_denies_all(self):
+        """Unauthenticated users cannot write to any collection."""
+        filt = await CollectionsFilter()({"payload": None, "req": _WRITE_REQ})
         assert not cql2_matches(
-            filt, {"id": "org.dept.data"}
-        ), "deeply prefixed collection 'org.dept.data' should not be visible without authentication"
+            filt, {"id": "public"}
+        ), "unauthenticated write should deny public collections"
+        assert not cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "unauthenticated write should deny prefixed collections"
 
     @pytest.mark.asyncio
     async def test_missing_payload_treated_as_unauthenticated(self):
         """A context dict without a 'payload' key is treated as unauthenticated."""
-        filt = await CollectionsFilter()({})
+        filt = await CollectionsFilter()({"req": _READ_REQ})
         assert cql2_matches(
             filt, {"id": "public"}
         ), "public collection should be visible when payload key is missing"
@@ -49,38 +105,61 @@ class TestCollectionsFilter:
             filt, {"id": "alice.data"}
         ), "prefixed collection should not be visible when payload key is missing"
 
+    # --- Authenticated user access (own prefix, other users, public) ---
+
     @pytest.mark.asyncio
-    async def test_authenticated_user_can_access_own_prefixed_collections(self):
-        """The preferred_username claim grants access to '{username}.*' collections."""
+    @pytest.mark.parametrize(
+        "req",
+        [
+            pytest.param(_READ_REQ, id="read"),
+            pytest.param(_WRITE_REQ, id="write"),
+        ],
+    )
+    async def test_authenticated_user_accesses_own_prefix(self, req):
+        """Users can access their own prefixed collections for both read and write."""
         token = {"preferred_username": "alice"}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": req})
         assert cql2_matches(
             filt, {"id": "alice.my-data"}
-        ), "user 'alice' should be able to access her own prefixed collection 'alice.my-data'"
+        ), "user 'alice' should access her own prefixed collection"
 
     @pytest.mark.asyncio
-    async def test_authenticated_user_cannot_access_other_users_collections(self):
+    @pytest.mark.parametrize(
+        "req",
+        [
+            pytest.param(_READ_REQ, id="read"),
+            pytest.param(_WRITE_REQ, id="write"),
+        ],
+    )
+    async def test_authenticated_user_denied_other_users_prefix(self, req):
         """A user cannot access collections prefixed with another user's name."""
         token = {"preferred_username": "alice"}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": req})
         assert not cql2_matches(
             filt, {"id": "bob.my-data"}
-        ), "user 'alice' should not be able to access 'bob.my-data'"
+        ), "user 'alice' should not access 'bob.my-data'"
 
     @pytest.mark.asyncio
-    async def test_authenticated_user_retains_public_access(self):
-        """Authentication does not revoke access to public collections."""
+    @pytest.mark.parametrize(
+        "req,expected",
+        [
+            pytest.param(_READ_REQ, True, id="read-allows-public"),
+            pytest.param(_WRITE_REQ, False, id="write-denies-public"),
+        ],
+    )
+    async def test_authenticated_public_collection_access(self, req, expected):
+        """Authenticated reads see public collections; writes do not."""
         token = {"preferred_username": "alice"}
-        filt = await CollectionsFilter()({"payload": token})
-        assert cql2_matches(
-            filt, {"id": "sentinel-2"}
-        ), "authenticated user should still see public collection 'sentinel-2'"
+        filt = await CollectionsFilter()({"payload": token, "req": req})
+        assert cql2_matches(filt, {"id": "sentinel-2"}) == expected
+
+    # --- Token without username ---
 
     @pytest.mark.asyncio
     async def test_token_without_username_only_gets_public_access(self):
-        """If preferred_username is missing, only public collections are visible."""
+        """If preferred_username is missing, only public collections are visible on read."""
         token: dict = {}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert cql2_matches(
             filt, {"id": "public"}
         ), "public collection should be visible even without preferred_username"
@@ -89,55 +168,101 @@ class TestCollectionsFilter:
         ), "prefixed collection should not be visible without preferred_username"
 
     @pytest.mark.asyncio
-    async def test_rw_group_grants_read_access_to_group_prefix(self):
-        """A /dss/{prefix} group grants read access to '{prefix}.*' collections."""
+    async def test_write_token_without_username_gets_no_access(self):
+        """A token without preferred_username gets no write access at all."""
+        token: dict = {}
+        filt = await CollectionsFilter()({"payload": token, "req": _WRITE_REQ})
+        assert not cql2_matches(
+            filt, {"id": "public"}
+        ), "write without username should deny public collections"
+        assert not cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "write without username should deny prefixed collections"
+
+    # --- Group-based access ---
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "req",
+        [
+            pytest.param(_READ_REQ, id="read"),
+            pytest.param(_WRITE_REQ, id="write"),
+        ],
+    )
+    async def test_rw_group_grants_access(self, req):
+        """A /dss/{prefix} group grants both read and write access."""
         token = {"preferred_username": "alice", "groups": ["/dss/org-dss-team"]}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": req})
         assert cql2_matches(
             filt, {"id": "org-dss-team.dataset"}
-        ), "rw group '/dss/org-dss-team' should grant access to 'org-dss-team.dataset'"
+        ), "rw group should grant access to 'org-dss-team.dataset'"
 
     @pytest.mark.asyncio
     async def test_rw_group_does_not_grant_access_to_other_prefixes(self):
         """A group only grants access to its own prefix, not unrelated prefixes."""
         token = {"preferred_username": "alice", "groups": ["/dss/org-dss-team"]}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert not cql2_matches(
             filt, {"id": "other-dss-org.dataset"}
         ), "group '/dss/org-dss-team' should not grant access to 'other-dss-org.dataset'"
 
     @pytest.mark.asyncio
-    async def test_ro_group_grants_read_access(self):
-        """A /dss/{prefix}-ro group grants read access to '{prefix}.*' collections."""
+    @pytest.mark.parametrize(
+        "req,expected",
+        [
+            pytest.param(_READ_REQ, True, id="read-grants"),
+            pytest.param(_WRITE_REQ, False, id="write-denies"),
+        ],
+    )
+    async def test_ro_group_access_depends_on_mode(self, req, expected):
+        """A -ro group grants read access but not write access."""
         token = {"preferred_username": "alice", "groups": ["/dss/org-dss-shared-ro"]}
-        filt = await CollectionsFilter()({"payload": token})
-        assert cql2_matches(
-            filt, {"id": "org-dss-shared.dataset"}
-        ), "ro group '/dss/org-dss-shared-ro' should grant read access to 'org-dss-shared.dataset'"
+        filt = await CollectionsFilter()({"payload": token, "req": req})
+        assert cql2_matches(filt, {"id": "org-dss-shared.dataset"}) == expected
 
     @pytest.mark.asyncio
     async def test_ro_group_public_still_visible(self):
         """Public collections remain visible alongside read-only group access."""
         token = {"preferred_username": "alice", "groups": ["/dss/org-dss-shared-ro"]}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert cql2_matches(
             filt, {"id": "public-data"}
         ), "public collection 'public-data' should remain visible with ro group membership"
 
     @pytest.mark.asyncio
-    async def test_mixed_rw_and_ro_groups_both_grant_read_access(self):
-        """Both rw and ro groups contribute collection prefixes during read access."""
+    @pytest.mark.parametrize(
+        "req,rw_expected,ro_expected",
+        [
+            pytest.param(_READ_REQ, True, True, id="read-both-grant"),
+            pytest.param(_WRITE_REQ, True, False, id="write-only-rw"),
+        ],
+    )
+    async def test_mixed_rw_and_ro_groups(self, req, rw_expected, ro_expected):
+        """Both group types contribute on read; only rw contributes on write."""
         token = {
             "preferred_username": "alice",
             "groups": ["/dss/proj-dss-alpha", "/dss/proj-dss-beta-ro"],
         }
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": req})
+        assert cql2_matches(filt, {"id": "proj-dss-alpha.data"}) == rw_expected
+        assert cql2_matches(filt, {"id": "proj-dss-beta.data"}) == ro_expected
+
+    @pytest.mark.asyncio
+    async def test_write_user_retains_own_prefix_with_ro_group(self):
+        """User can still write to own prefix even when only holding -ro groups."""
+        token = {
+            "preferred_username": "alice",
+            "groups": ["/dss/org-dss-shared-ro"],
+        }
+        filt = await CollectionsFilter()({"payload": token, "req": _WRITE_REQ})
         assert cql2_matches(
-            filt, {"id": "proj-dss-alpha.data"}
-        ), "rw group should grant read access to 'proj-dss-alpha.data'"
-        assert cql2_matches(
-            filt, {"id": "proj-dss-beta.data"}
-        ), "ro group should also grant read access to 'proj-dss-beta.data'"
+            filt, {"id": "alice.data"}
+        ), "user should retain write access to own prefix despite only having ro groups"
+        assert not cql2_matches(
+            filt, {"id": "org-dss-shared.dataset"}
+        ), "ro group should not grant write access"
+
+    # --- Invalid / malformed group handling ---
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -152,7 +277,7 @@ class TestCollectionsFilter:
     async def test_invalid_group_format_grants_no_extra_access(self, group):
         """Groups that don't match '/dss/{name-with-dss-infix}' are silently ignored."""
         token = {"preferred_username": "alice", "groups": [group]}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert not cql2_matches(
             filt, {"id": "org-dss-team.data"}
         ), f"invalid group '{group}' should not grant access to 'org-dss-team.data'"
@@ -167,7 +292,7 @@ class TestCollectionsFilter:
     async def test_groups_claim_not_a_list_is_ignored(self):
         """If the 'groups' claim is a string instead of a list, it is ignored gracefully."""
         token = {"preferred_username": "alice", "groups": "not-a-list"}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert cql2_matches(
             filt, {"id": "public"}
         ), "public access should work when groups claim is malformed"
@@ -182,13 +307,30 @@ class TestCollectionsFilter:
     async def test_no_groups_claim_still_allows_username_access(self):
         """A token without a 'groups' claim still grants username-based access."""
         token = {"preferred_username": "bob"}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert cql2_matches(
             filt, {"id": "bob.data"}
         ), "user 'bob' should access 'bob.data' even without any groups claim"
         assert cql2_matches(
             filt, {"id": "public"}
         ), "public access should work without groups claim"
+
+    @pytest.mark.asyncio
+    async def test_empty_groups_list_grants_no_group_access(self):
+        """An empty groups list contributes no extra collection prefixes."""
+        token = {"preferred_username": "alice", "groups": []}
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
+        assert cql2_matches(
+            filt, {"id": "public"}
+        ), "public access should work with empty groups list"
+        assert cql2_matches(
+            filt, {"id": "alice.data"}
+        ), "username-based access should work with empty groups list"
+        assert not cql2_matches(
+            filt, {"id": "org-dss-team.data"}
+        ), "empty groups list should not grant access to any group-prefixed collection"
+
+    # --- Input sanitization ---
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -203,8 +345,7 @@ class TestCollectionsFilter:
     async def test_unsafe_username_is_rejected(self, username):
         """Usernames with unsafe characters must not be interpolated into CQL2."""
         token = {"preferred_username": username}
-        filt = await CollectionsFilter()({"payload": token})
-        # Should only contain the public-collection policy, no user prefix
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert cql2_matches(
             filt, {"id": "public"}
         ), "public access should still work with unsafe username"
@@ -228,7 +369,7 @@ class TestCollectionsFilter:
     async def test_unsafe_group_prefix_is_rejected(self, group, derived_prefix):
         """Group names that yield unsafe prefixes must not be interpolated into CQL2."""
         token = {"preferred_username": "alice", "groups": [group]}
-        filt = await CollectionsFilter()({"payload": token})
+        filt = await CollectionsFilter()({"payload": token, "req": _READ_REQ})
         assert not cql2_matches(
             filt, {"id": f"{derived_prefix}.data"}
         ), f"unsafe group {group!r} should not produce a filter granting access"
@@ -236,49 +377,42 @@ class TestCollectionsFilter:
             filt, {"id": "alice.data"}
         ), "username-based access should still work despite unsafe group"
 
-    @pytest.mark.asyncio
-    async def test_empty_groups_list_grants_no_group_access(self):
-        """An empty groups list contributes no extra collection prefixes."""
-        token = {"preferred_username": "alice", "groups": []}
-        filt = await CollectionsFilter()({"payload": token})
-        assert cql2_matches(
-            filt, {"id": "public"}
-        ), "public access should work with empty groups list"
-        assert cql2_matches(
-            filt, {"id": "alice.data"}
-        ), "username-based access should work with empty groups list"
-        assert not cql2_matches(
-            filt, {"id": "org-dss-team.data"}
-        ), "empty groups list should not grant access to any group-prefixed collection"
-
 
 class TestItemsFilter:
     """ItemsFilter generates CQL2 filters matching on the 'collection' property."""
 
     @pytest.mark.asyncio
-    async def test_unauthenticated_allows_items_in_public_collections(self):
-        """Items in public collections (no '.' in collection name) are visible without auth."""
-        filt = await ItemsFilter()({"payload": None})
-        assert cql2_matches(
-            filt, {"collection": "sentinel-2"}
-        ), "item in public collection 'sentinel-2' should be visible without authentication"
+    @pytest.mark.parametrize(
+        "collection_id,expected",
+        [
+            pytest.param("sentinel-2", True, id="public-allowed"),
+            pytest.param("alice.my-data", False, id="prefixed-denied"),
+        ],
+    )
+    async def test_unauthenticated_read_access(self, collection_id, expected):
+        """Unauthenticated reads allow items in public collections but deny prefixed."""
+        filt = await ItemsFilter()({"payload": None, "req": _READ_REQ})
+        assert cql2_matches(filt, {"collection": collection_id}) == expected
 
     @pytest.mark.asyncio
-    async def test_unauthenticated_denies_items_in_prefixed_collections(self):
-        """Items in prefixed collections require authentication."""
-        filt = await ItemsFilter()({"payload": None})
+    async def test_unauthenticated_write_denies_all(self):
+        """Unauthenticated users cannot write items to any collection."""
+        filt = await ItemsFilter()({"payload": None, "req": _WRITE_REQ})
         assert not cql2_matches(
-            filt, {"collection": "alice.my-data"}
-        ), "item in prefixed collection 'alice.my-data' should not be visible without authentication"
+            filt, {"collection": "public"}
+        ), "unauthenticated write should deny items in public collections"
+        assert not cql2_matches(
+            filt, {"collection": "alice.data"}
+        ), "unauthenticated write should deny items in prefixed collections"
 
     @pytest.mark.asyncio
-    async def test_authenticated_user_can_access_own_and_group_items(self):
-        """Authenticated users can access items in username-prefixed and group collections."""
+    async def test_authenticated_read_access(self):
+        """Authenticated users can read items in own, group, and public collections."""
         token = {
             "preferred_username": "alice",
             "groups": ["/dss/org-dss-shared"],
         }
-        filt = await ItemsFilter()({"payload": token})
+        filt = await ItemsFilter()({"payload": token, "req": _READ_REQ})
         assert cql2_matches(
             filt, {"collection": "alice.data"}
         ), "user 'alice' should access items in her own collection 'alice.data'"
@@ -291,3 +425,44 @@ class TestItemsFilter:
         assert not cql2_matches(
             filt, {"collection": "bob.data"}
         ), "user 'alice' should not access items in 'bob.data'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "collection_id,expected",
+        [
+            pytest.param("alice.data", True, id="own-prefix-allowed"),
+            pytest.param("public", False, id="public-denied"),
+        ],
+    )
+    async def test_authenticated_write_basic_access(self, collection_id, expected):
+        """Write allows own prefix but denies public collections."""
+        token = {"preferred_username": "alice"}
+        filt = await ItemsFilter()({"payload": token, "req": _WRITE_REQ})
+        assert cql2_matches(filt, {"collection": collection_id}) == expected
+
+    @pytest.mark.asyncio
+    async def test_write_ro_group_denied(self):
+        """A -ro group does NOT grant write access to items."""
+        token = {
+            "preferred_username": "alice",
+            "groups": ["/dss/org-dss-shared-ro"],
+        }
+        filt = await ItemsFilter()({"payload": token, "req": _WRITE_REQ})
+        assert not cql2_matches(
+            filt, {"collection": "org-dss-shared.data"}
+        ), "ro group should not grant write access to items"
+
+    @pytest.mark.asyncio
+    async def test_write_rw_group_grants_access(self):
+        """A rw group grants write access to items in that group's collections."""
+        token = {
+            "preferred_username": "alice",
+            "groups": ["/dss/org-dss-shared"],
+        }
+        filt = await ItemsFilter()({"payload": token, "req": _WRITE_REQ})
+        assert cql2_matches(
+            filt, {"collection": "org-dss-shared.data"}
+        ), "rw group should grant write access to items in 'org-dss-shared.data'"
+        assert not cql2_matches(
+            filt, {"collection": "bob.data"}
+        ), "rw group should not grant write access to unrelated collections"

--- a/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
+++ b/argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py
@@ -8,9 +8,9 @@ _READ_REQ = {"method": "GET", "path": "/collections"}
 _WRITE_REQ = {"method": "POST", "path": "/collections"}
 
 
-def cql2_matches(cql2_text: str, item: dict) -> bool:
-    """Parse a CQL2-text expression and test it against an item dict."""
-    expr = Expr(cql2_text)
+def cql2_matches(cql2_json: dict, item: dict) -> bool:
+    """Parse a CQL2-JSON expression and test it against an item dict."""
+    expr = Expr(cql2_json)
     expr.validate()
     return expr.matches(item)
 


### PR DESCRIPTION
## What I'm changing

Build out CQL2 filtering logic as per the discussion in https://github.com/EOEPCA/resource-discovery/issues/203.

The CQL2 filters are built out with the following logic:

* Anonymous and authenticated users can read from any collection that doesn't have a period in it (i.e. `NOT LIKE '%.%'`)
* Authenticated users can read-from/write-to any collection prefixed with their username (i.e. `LIKE '{username}.%')
* Authenticated users can read from collections with names contained in their groups claim of their JWT with a name matching `/dss/*-dss-*-ro`
* Authenticated users can read-from/write-to collections with names contained in their groups  claim of their JWT with a name matching `/dss/*-dss-*` (groups with `-mgr` suffixes are ignored)

> [!WARNING]
> It's worth pointing out that Collections permissions and Items permissions are coupled together. A user will have permissions to create/edit/delete an unlimited number of collections prepended with ther username and can create/edit/delete any collection mentioned in their `groups` array unless it contains a `-ro` suffix. i.e. permission to write items to a collection implies permissions to delete the collection itself. I believe this matches the design described in https://github.com/EOEPCA/resource-discovery/issues/203 but bears repeating.

## How I did it

Filled in the CQL2 Factory classes. The logic for Collections and Items is effectively identical, aside from us filtering on the `id` property for Collections and the `collection` property for Items.

I additionally added a test suite with 55 unit tests to validate behavior. These tests run within Github Actions or can be run locally with a command like `uv run --with pytest --with pytest-asyncio --with cql2 pytest argocd/eoepca/data-access/parts/stac-auth-proxy/test_eoepca_filters.py`.

## How you can test it

> [!IMPORTANT]
> This codebase depends on STAC Auth Proxy >= `v1.0.0`.