### PR TITLE
Add protected APISIX route for OpenEO /jobs and /files

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -26,6 +26,34 @@ spec:
         # Allow CORS access
         - name: cors
           enable: true
+    # Authorized access to OpenEO protected endpoints (jobs, files)
+    - name: openeo-protected
+      match:
+        hosts:
+          - openeo-eurac.develop.eoepca.org
+        paths:
+          - /openeo/1.1.0/jobs*
+          - /openeo/1.1.0/files*
+          - /openeo/1.1.0/me*
+      backends:
+        - serviceName: openeo-openeo-argo
+          servicePort: 8000
+      plugins:
+        # Authn - expect JWT in Authorization: Bearer header
+        - name: openid-connect
+          enable: true
+          config:
+            client_id: "openeo-apisix"
+            client_secret: "fdeb5f95-b913-45f9-8736-afb618601ad3"
+            discovery: "https://edp-portal.eurac.edu/auth/realms/edp/.well-known/openid-configuration"
+            realm: edp
+            use_jwks: true
+            bearer_only: false
+            set_access_token_header: true
+            access_token_in_authorization_header: true
+        # Allow CORS access
+        - name: cors
+          enable: true
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
## Summary
- Adds protected APISIX route for `/jobs`, `/files`, and `/me` endpoints
- Uses `openid-connect` plugin with EURAC Keycloak (`edp-portal.eurac.edu/auth/realms/edp`)
- Public endpoints (collections, processes, credentials) remain unauthenticated
- Created confidential Keycloak client `openeo-apisix` on EURAC Keycloak for APISIX token validation

## Context
The existing `ingress-openeo.yaml` only routes public discovery endpoints. Authenticated endpoints like `/jobs` and `/files` return 404 because they are not included in the APISIX route configuration. This PR adds a second route with OIDC authentication for these protected endpoints.

## Test plan
- [ ] Verify `/jobs` endpoint returns 401 without token (instead of 404)
- [ ] Verify `/jobs` endpoint returns 200 with valid EURAC Keycloak token
- [ ] Verify public endpoints (collections, processes) still work without auth
- [ ] Verify CORS headers are present on protected endpoints