### PR TITLE
fix(openeo): Set bearer_only to true for protected routes

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -48,7 +48,7 @@ spec:
             discovery: "https://edp-portal.eurac.edu/auth/realms/edp/.well-known/openid-configuration"
             realm: edp
             use_jwks: true
-            bearer_only: false
+            bearer_only: true
             set_access_token_header: true
             access_token_in_authorization_header: true
         # Allow CORS access


### PR DESCRIPTION
## Summary
- Set `bearer_only: true` in APISIX `openid-connect` plugin for OpenEO protected endpoints (`/jobs`, `/files`, `/me`)
- With `bearer_only: false`, APISIX tried to manage full OIDC sessions, rejecting valid Bearer tokens from the web editor with 401
- With `bearer_only: true`, APISIX simply validates the JWT signature via Keycloak's JWKS endpoint, accepting any valid token from the realm regardless of which client issued it