### PR TITLE
fix(openeo): Pass original Authorization header through APISIX unchanged

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -39,7 +39,7 @@ spec:
         - serviceName: openeo-openeo-argo
           servicePort: 8000
       plugins:
-        # Authn - expect JWT in Authorization: Bearer header
+        # Authn - validate JWT via JWKS and pass original Authorization header through
         - name: openid-connect
           enable: true
           config:
@@ -49,8 +49,8 @@ spec:
             realm: edp
             use_jwks: true
             bearer_only: true
-            set_access_token_header: true
-            access_token_in_authorization_header: true
+            set_access_token_header: false
+            access_token_in_authorization_header: false
         # Allow CORS access
         - name: cors
           enable: true


### PR DESCRIPTION
## Summary
- Set `set_access_token_header: false` and `access_token_in_authorization_header: false` in the APISIX `openid-connect` plugin
- The plugin was replacing the `Authorization` header with the raw JWT, breaking the OpenEO backend
- The OpenEO API expects `Authorization: Bearer oidc/<provider>/<token>` — it splits on `/` to extract method, provider, and token
- With the previous config, APISIX forwarded `Bearer <raw-jwt>` which caused a Pydantic validation error in the backend (`method` not a valid enum member)
- Now APISIX validates the JWT via JWKS but passes the original `Authorization` header through to the backend unchanged