### PR TITLE
fix(openeo): Extract raw JWT from OpenEO token format for APISIX validation

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -39,7 +39,27 @@ spec:
         - serviceName: openeo-openeo-argo
           servicePort: 8000
       plugins:
-        # Authn - validate JWT via JWKS and pass original Authorization header through
+        # Extract raw JWT from OpenEO's 'Bearer oidc/<provider>/<jwt>' format
+        # and place it in X-Real-Token for openid-connect to validate,
+        # while preserving the original Authorization header for the backend.
+        - name: serverless-pre-function
+          enable: true
+          config:
+            phase: rewrite
+            functions:
+              - "return function(conf, ctx)
+                  local core = require('apisix.core')
+                  local auth = core.request.header(ctx, 'Authorization') or ''
+                  -- Match 'Bearer oidc/<provider>/<jwt>'
+                  local jwt = auth:match('^[Bb]earer%s+oidc/[^/]+/(.+)$')
+                  if jwt then
+                    core.request.set_header(ctx, 'X-Real-Token', jwt)
+                    -- Temporarily set Authorization to raw Bearer for openid-connect
+                    core.request.set_header(ctx, 'Authorization', 'Bearer ' .. jwt)
+                    ngx.ctx._openeo_original_auth = auth
+                  end
+                end"
+        # Validate the raw JWT via JWKS
         - name: openid-connect
           enable: true
           config:
@@ -51,6 +71,19 @@ spec:
             bearer_only: true
             set_access_token_header: false
             access_token_in_authorization_header: false
+        # Restore original Authorization header before forwarding to backend
+        - name: serverless-pre-function
+          enable: true
+          config:
+            phase: access
+            functions:
+              - "return function(conf, ctx)
+                  local core = require('apisix.core')
+                  local original = ngx.ctx._openeo_original_auth
+                  if original then
+                    core.request.set_header(ctx, 'Authorization', original)
+                  end
+                end"
         # Allow CORS access
         - name: cors
           enable: true


### PR DESCRIPTION
## Summary
- The OpenEO web editor sends `Authorization: Bearer oidc/<provider>/<jwt>` (OpenEO's standard token format)
- APISIX `openid-connect` plugin expects a raw JWT and rejected the whole string as invalid
- Added `serverless-pre-function` (rewrite phase) to extract the raw JWT and temporarily set it as the Bearer token for APISIX validation
- After validation passes, a second `serverless-pre-function` (access phase) restores the original `Authorization` header so the OpenEO backend receives the expected `oidc/<provider>/<jwt>` format

## Flow
1. Request arrives with `Authorization: Bearer oidc/eurac-keycloak/<jwt>`
2. Pre-function extracts `<jwt>`, sets `Authorization: Bearer <jwt>` temporarily
3. `openid-connect` validates `<jwt>` via JWKS — accepts or rejects
4. Pre-function restores `Authorization: Bearer oidc/eurac-keycloak/<jwt>`
5. OpenEO backend receives the original header and parses it correctly