### PR TITLE
fix(openeo): Use request header and before_proxy phase to restore OpenEO auth header

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -39,9 +39,8 @@ spec:
         - serviceName: openeo-openeo-argo
           servicePort: 8000
       plugins:
-        # Extract raw JWT from OpenEO's 'Bearer oidc/<provider>/<jwt>' format
-        # and place it in X-Real-Token for openid-connect to validate,
-        # while preserving the original Authorization header for the backend.
+        # Step 1: Extract raw JWT from 'Bearer oidc/<provider>/<jwt>' and stash
+        # the original header in X-Openeo-Auth before APISIX validates.
         - name: serverless-pre-function
           enable: true
           config:
@@ -50,16 +49,13 @@ spec:
               - "return function(conf, ctx)
                   local core = require('apisix.core')
                   local auth = core.request.header(ctx, 'Authorization') or ''
-                  -- Match 'Bearer oidc/<provider>/<jwt>'
                   local jwt = auth:match('^[Bb]earer%s+oidc/[^/]+/(.+)$')
                   if jwt then
-                    core.request.set_header(ctx, 'X-Real-Token', jwt)
-                    -- Temporarily set Authorization to raw Bearer for openid-connect
+                    core.request.set_header(ctx, 'X-Openeo-Auth', auth)
                     core.request.set_header(ctx, 'Authorization', 'Bearer ' .. jwt)
-                    ngx.ctx._openeo_original_auth = auth
                   end
                 end"
-        # Validate the raw JWT via JWKS
+        # Step 2: Validate the raw JWT via JWKS
         - name: openid-connect
           enable: true
           config:
@@ -71,17 +67,18 @@ spec:
             bearer_only: true
             set_access_token_header: false
             access_token_in_authorization_header: false
-        # Restore original Authorization header before forwarding to backend
+        # Step 3: Restore original OpenEO Authorization header for the backend
         - name: serverless-pre-function
           enable: true
           config:
-            phase: access
+            phase: before_proxy
             functions:
               - "return function(conf, ctx)
                   local core = require('apisix.core')
-                  local original = ngx.ctx._openeo_original_auth
+                  local original = core.request.header(ctx, 'X-Openeo-Auth')
                   if original then
                     core.request.set_header(ctx, 'Authorization', original)
+                    core.request.set_header(ctx, 'X-Openeo-Auth', nil)
                   end
                 end"
         # Allow CORS access


### PR DESCRIPTION
## Summary
Fixes a reliability issue in the previous approach (PR #122) for handling OpenEO's `Bearer oidc/<provider>/<jwt>` token format with APISIX.

## Problems with PR #122
- Stored original `Authorization` in `ngx.ctx` — unreliable across APISIX plugin phases
- Second `serverless-pre-function` ran in `access` phase, same as `openid-connect` — ordering not guaranteed

## Fix
- Store original `Authorization` header in `X-Openeo-Auth` **request header** — reliable, persists across all phases
- Restore in `before_proxy` phase — guaranteed to run **after** `openid-connect` (access phase) and before request is forwarded to backend
- Remove `X-Openeo-Auth` before forwarding so the backend doesn't see it

## Flow
1. `rewrite`: Extract raw JWT → set `Authorization: Bearer <jwt>`, stash original in `X-Openeo-Auth`
2. `access`: `openid-connect` validates raw JWT via JWKS
3. `before_proxy`: Restore `Authorization: Bearer oidc/<provider>/<jwt>` from `X-Openeo-Auth`, remove stash header
4. Backend receives original OpenEO token format and parses it correctly