### PR TITLE
fix(openeo): use rclone-backed PVC for workspace storage

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/helm-openeo-argoworkflows.yaml
@@ -76,6 +76,9 @@ spec:
             cpu: 250m
             memory: 256Mi
 
+        persistence:
+          existingClaim: openeo-workspace
+
         autoscaling:
           enabled: false
 

--- a/argocd/eoepca/openeo-argoworkflows/parts/workspace-pvc.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/workspace-pvc.yaml
@@ -1,0 +1,36 @@
+---
+# Rclone credentials secret for MinIO-backed workspace storage.
+# The rclone CSI driver reads these to mount the S3 bucket as a filesystem.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openeo-rclone-secret
+  namespace: openeo
+stringData:
+  remote: "s3"
+  remotePath: "openeo-workspace"
+  configData: |
+    [s3]
+    type = s3
+    provider = Other
+    env_auth = false
+    endpoint = https://minio.develop.eoepca.org
+    region = eoepca-demo
+    access_key_id = ""
+    secret_access_key = ""
+---
+# PVC backed by the rclone CSI driver so both the API and executor pods
+# can read/write job results via the platform MinIO storage.
+# The helm chart always references this PVC by name "openeo-workspace".
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openeo-workspace
+  namespace: openeo
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: rclone
+  resources:
+    requests:
+      storage: 8Gi


### PR DESCRIPTION
Closes #125

## Problem

The helm chart was creating its own `openeo-workspace` PVC with `ReadWriteOnce` and no storage class. On the EOEPCA cluster this results in an unbound PVC, causing the executor to write results to a path inaccessible to the API pod — leading to `500` errors on `GET /jobs/{id}/results`.

## Solution

Use the standard EOEPCA storage class `managed-nfs-storage-retain` with `ReadWriteMany`, consistent with how other services (IAM, identity-service, zoo) handle storage on the platform.

- Set `persistence.storageClassName: managed-nfs-storage-retain` and `accessModes: ReadWriteMany` in helm values
- Remove `workspace-pvc.yaml` (rclone secret + custom PVC no longer needed)

## Dependency

Requires `Eurac-Research-Institute-for-EO/charts#3` to be merged first, which adds `storageClassName` and `accessModes` support to the `openeo-argo` chart.