### PR TITLE
fix(openeo): allow signed URL file downloads through APISIX

### DIFF
--- a/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
+++ b/argocd/eoepca/openeo-argoworkflows/parts/ingress-openeo.yaml
@@ -50,6 +50,10 @@ spec:
                   local core = require('apisix.core')
                   local http = require('resty.http')
                   local cjson = require('cjson')
+                  local uri_args = core.request.get_uri_args(ctx)
+                  if uri_args and uri_args['Signature'] then
+                    return
+                  end
                   local auth = core.request.header(ctx, 'Authorization') or ''
                   local jwt = auth:match('^[Bb]earer%s+oidc/[^/]+/(.+)$')
                   if not jwt then


### PR DESCRIPTION
## Summary

- Job result file downloads use HMAC-signed URLs (`?Expires=...&Signature=...`)
- Browser-initiated downloads (clicking the Download button in the web editor) cannot carry Bearer tokens → APISIX was rejecting them with 401
- Fix: skip Bearer token validation in the APISIX Lua function when the request contains a `Signature` query param; the backend independently validates the HMAC signature

## Root cause

`GET /openeo/1.1.0/files/{job_id}/RESULTS/{file}?Expires=...&Signature=...` hits the `openeo-protected` APISIX route which requires `Authorization: Bearer oidc/...`. Plain browser downloads have no way to attach that header.

## Test plan

- [ ] Run a batch job via the web editor
- [ ] Click "Download Results" — popup appears with artifact name
- [ ] Click Download — file downloads successfully (previously got 401)