### PR TITLE
feat(apisix): enable prometheus metrics for all endpoints

### DIFF
--- a/argocd/infra/apisix/parts/apisixglobalrule-prometheus.yaml
+++ b/argocd/infra/apisix/parts/apisixglobalrule-prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: apisix.apache.org/v2
+kind: ApisixGlobalRule
+metadata:
+  name: prometheus
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: prometheus
+      enable: true

--- a/argocd/infra/apisix/parts/values/apisix-values.yaml
+++ b/argocd/infra/apisix/parts/values/apisix-values.yaml
@@ -5,7 +5,6 @@
 # This may change in the future.
 
 apisix:
-
   enableIPv6: false
   enableServerTokens: false
 
@@ -25,6 +24,9 @@ apisix:
     role: traditional
     role_traditional:
       config_provider: yaml # Standalone Mode
+
+  prometheus:
+    enabled: true
 
 etcd:
   # Etcd is not needed in standalone mode.


### PR DESCRIPTION
Currently, there is no way to see http response times or similar metrics for routes configured with Apisix. By enabling the prometheus endpoint in the values.yaml and adding a global rule to enable the prometheus plugin on all routes we will be able to scrape the metrics.